### PR TITLE
clarify two separate `const` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1903,7 +1903,9 @@ const test = "x";
 
 // error cant reassign a const
 test ="y";
+```
 
+```js
 const test = {key: 'value'};
 
 // OK (object attributes are not protected)


### PR DESCRIPTION
It's a little ambiguous that the second example of `const` isn't re-declaring the already used `test`. This separates the code examples into two distinct blocks.
